### PR TITLE
use ::osfamily in place of ::operatingsystem + add explicit redhat suppo...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,83 +16,86 @@ class libvirt::params {
 
   ### Application related parameters
 
-  $package = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => 'libvirt-bin',
-    default                   => 'libvirt',
+  $package = $::osfamily ? {
+    'debian' => 'libvirt-bin',
+    'redhat' => 'libvirt',
+    default  => 'libvirt',
   }
 
-  $service = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => 'libvirt-bin',
-    default                   => 'libvirtd',
+  $service = $::osmfaily ? {
+    'debian' => 'libvirt-bin',
+    'redhat' => 'libvirtd',
+    default  => 'libvirtd',
   }
 
-  $service_guests = $::operatingsystem ? {
+  $service_guests = $::osfamily ? {
     default => 'libvirt-guests',
   }
 
-  $service_status = $::operatingsystem ? {
+  $service_status = $::osfamily ? {
     default => true,
   }
 
-  $process = $::operatingsystem ? {
+  $process = $::osfamily ? {
     default => 'libvirtd',
   }
 
-  $process_args = $::operatingsystem ? {
+  $process_args = $::osfamily ? {
     default => '',
   }
 
-  $process_user = $::operatingsystem ? {
+  $process_user = $::osfamily ? {
     default => 'root',
   }
 
-  $config_dir = $::operatingsystem ? {
+  $config_dir = $::osfamily ? {
     default => '/etc/libvirt',
   }
 
-  $config_file = $::operatingsystem ? {
+  $config_file = $::osfamily ? {
     default => '/etc/libvirt/libvirtd.conf',
   }
 
-  $config_file_mode = $::operatingsystem ? {
+  $config_file_mode = $::osfamily ? {
     default => '0644',
   }
 
-  $config_file_owner = $::operatingsystem ? {
+  $config_file_owner = $::osfamily ? {
     default => 'root',
   }
 
-  $config_file_group = $::operatingsystem ? {
+  $config_file_group = $::osfamily ? {
     default => 'root',
   }
 
-  $config_file_init = $::operatingsystem ? {
+  $config_file_init = $::osfamily ? {
     /(?i:Debian|Ubuntu|Mint)/ => '/etc/default/libvirt',
     default                   => '/etc/sysconfig/libvirt',
   }
 
-  $pid_file = $::operatingsystem ? {
+  $pid_file = $::osfamily ? {
     default => '/var/run/libvirt/network/default.pid',
   }
 
-  $data_dir = $::operatingsystem ? {
+  $data_dir = $::osfamily ? {
     default => '/var/lib/libvirt',
   }
 
-  $log_dir = $::operatingsystem ? {
+  $log_dir = $::osfamily ? {
     default => '/var/log/libvirt',
   }
 
-  $log_file = $::operatingsystem ? {
+  $log_file = $::osfamily ? {
     default => '/var/log/libvirt/libvirtd.log',
   }
 
-  $has_guests_service = $operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => $lsbdistcodename ? {
+  $has_guests_service = $::osfamily ? {
+    'debian' => $::lsbdistcodename ? {
       'wheezy' => true,
       default  => false,
     },
-    default                   => true,
+    'redhat' => true,
+    default  => true,
   }
 
   $port = ''

--- a/spec/classes/libvirt_spec.rb
+++ b/spec/classes/libvirt_spec.rb
@@ -18,15 +18,34 @@ describe 'libvirt' do
     it { should contain_package('libvirt').with_ensure('1.0.42') }
   end
 
-  describe 'Test services libvirt_guests with debian host' do
-    let(:facts) { { :operatingsystem => 'Debian' } }
-    it { should_not contain_service('libvirt_guests').with_ensure('running') }
-    it { should_not contain_service('libvirt_guests').with_enable('true') }
-  end
+  describe 'libvirt_guest service' do
+    describe 'on debian' do
+      let(:facts) { { :osfamily => 'Debian' } }
 
-  describe 'Test services libvirt_guests without debian host' do
-    it { should contain_service('libvirt_guests').with_ensure('running') }
-    it { should contain_service('libvirt_guests').with_enable('true') }
+      it do
+        should_not contain_service('libvirt_guests').
+          with_ensure('running').
+          with_enable('true')
+      end
+    end
+
+    describe 'on redhat' do
+      let(:facts) { { :osfamily => 'RedHat' } }
+
+      it do
+        should contain_service('libvirt_guests').
+          with_ensure('running').
+          with_enable('true')
+      end
+    end
+
+    describe 'with no operatingsystem/osfamily' do
+      it do
+        should contain_service('libvirt_guests').
+          with_ensure('running').
+          with_enable('true')
+      end
+    end
   end
 
   describe 'Test standard installation with monitoring and firewalling' do


### PR DESCRIPTION
...rt

This simplifies having to explicitly name all Debian like operating
systems and makes it easy to support the entire RedHat family (I need
support for RHEL, Centos, and Scientific)
