### PR TITLE
add config_file_content param to libvirt class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -244,6 +244,7 @@ class libvirt (
   $config_file_owner   = params_lookup( 'config_file_owner' ),
   $config_file_group   = params_lookup( 'config_file_group' ),
   $config_file_init    = params_lookup( 'config_file_init' ),
+  $config_file_content = params_lookup( 'config_file_content' ),
   $pid_file            = params_lookup( 'pid_file' ),
   $data_dir            = params_lookup( 'data_dir' ),
   $log_dir             = params_lookup( 'log_dir' ),
@@ -328,9 +329,13 @@ class libvirt (
     default   => $libvirt::source,
   }
 
-  $manage_file_content = $libvirt::template ? {
-    ''        => undef,
-    default   => template($libvirt::template),
+  if $libvirt::template {
+    $manage_file_content = $libvirt::template ? {
+      ''        => undef,
+      default   => template($libvirt::template),
+    }
+  } else {
+    $manage_file_content = $libvirt::config_file_content
   }
 
   ### Managed resources

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,10 @@ class libvirt::params {
     default                   => '/etc/sysconfig/libvirt',
   }
 
+  $config_file_content = $::operatingsystem ? {
+    default => undef,
+  }
+
   $pid_file = $::operatingsystem ? {
     default => '/var/run/libvirt/network/default.pid',
   }

--- a/spec/classes/libvirt_spec.rb
+++ b/spec/classes/libvirt_spec.rb
@@ -112,6 +112,16 @@ describe 'libvirt' do
 
   end
 
+  describe 'Test customizations - config_file_content' do
+    let(:params) {{ :config_file_content => "foo: bar\nbaz: quix\n" }}
+
+    it 'should generate a config file' do
+      should contain_file('libvirt.conf').
+        with_content(/^foo: bar$/).
+        with_content(/^baz: quix$/)
+    end
+  end
+
   describe 'Test customizations - source' do
     let(:params) { {:source => "puppet://modules/libvirt/spec" , :source_dir => "puppet://modules/libvirt/dir/spec" , :source_dir_purge => true } }
 


### PR DESCRIPTION
This is to allow a content string to be passed directly to the
`libvirt.conf` file resource.
